### PR TITLE
Cluster support with spring session

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+## Prerequisites
+* [Node.js](https://nodejs.org/en/)
+* java 8
+* [git](https://git-scm.com/)
+* maven 3
+* docker
+* docker-compose
+
+## Getting started with docker (3 commands)
+* install dependencies and build front-end
+```
+mvn clean install -PUI
+```
+* install dependencies and build back-end
+```
+mvn clean install
+```
+* start environment in one command and see http://localhost:8080 (or separately node 1 http://localhost:8081 and node 2 http://localhost:8081)
+```
+docker-compose up -d
+```
+* (optional) for remote debug ([IntelliJ](https://www.jetbrains.com/help/idea/tutorial-remote-debug.html), [Eclipse](https://www.eclipse.org/jetty/documentation/current/enable-remote-debugging.html)) use 
+##### node 1
+```
+-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8981
+```
+##### node 2
+```
+-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8982
+```
+
+
+## Second and further starts with docker
+Fast apply changes to backend. 
+Let us assume we changed only backend (so we'll skip mvn clean install -PUI)
+```
+docker-compose stop tesler-doc-node-1
+docker-compose stop tesler-doc-node-2
+docker-compose rm -sfv tesler-doc-node-1
+docker-compose rm -sfv tesler-doc-node-2
+mvn clean install && docker-compose up -d tesler-doc-node-1 && docker-compose up -d tesler-doc-node-2
+docker-compose ps
+```
+
+Full clean restart. For local development only!
+```
+docker-compose stop
+docker-compose rm -sfv
+docker system prune
+Y
+docker volume prune
+Y
+mvn clean install -PUI && mvn clean install && docker-compose up -d
+docker-compose ps
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+version: '3.6'
+
+services:
+  nginx:
+    image: nginx:latest
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - 8080:8080
+    depends_on:
+      - tesler-doc-node-1
+      - tesler-doc-node-2
+  tesler-doc-node-1:
+    image: openjdk:8
+    environment:
+      DATABASE_DRIVER: 'org.postgresql.Driver'
+      DATABASE_URL: 'jdbc:postgresql://pgs:5432/postgres'
+      DATABASE_USER: 'postgres'
+      DATABASE_PASSWORD: 'postgres'
+    ports:
+      - 8081:8080
+      - 8981:8989
+    volumes:
+      - type: bind
+        source: ./tesler-doc-app/
+        target: /tmp/tesler-doc-app/
+        read_only: true
+    command:  bash -c "cp -avr /tmp/tesler-doc-app/target/ /opt/tesler-doc-app/
+      && cd /opt/tesler-doc-app/
+      && chmod +x tesler-doc-app-exec.jar
+      && java '-agentlib:jdwp=transport=dt_socket,server=y,address=8989,suspend=n' -jar tesler-doc-app-exec.jar"
+    depends_on:
+      - pgs
+  tesler-doc-node-2:
+    image: openjdk:8
+    environment:
+      DATABASE_DRIVER: 'org.postgresql.Driver'
+      DATABASE_URL: 'jdbc:postgresql://pgs:5432/postgres'
+      DATABASE_USER: 'postgres'
+      DATABASE_PASSWORD: 'postgres'
+    ports:
+      - 8082:8080
+      - 8982:8989
+    volumes:
+      - type: bind
+        source: ./tesler-doc-app/
+        target: /tmp/tesler-doc-app/
+        read_only: true
+    command: bash -c "cp -avr /tmp/tesler-doc-app/target/ /opt/tesler-doc-app/
+      && cd /opt/tesler-doc-app/
+      && chmod +x tesler-doc-app-exec.jar
+      && java '-agentlib:jdwp=transport=dt_socket,server=y,address=8989,suspend=n' -jar tesler-doc-app-exec.jar"
+    depends_on:
+      - pgs
+  pgs:
+    image: postgres:alpine
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_PASSWORD=postgres
+    expose:
+      - 5432
+    ports:
+      - 5432:5432

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,24 @@
+events {
+   worker_connections   2000;
+  }
+
+http {
+
+  server {
+    listen 8080;
+    server_name nginx;
+
+    location / {
+       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header Host $host;
+
+       proxy_pass http://api_backend;
+     }
+
+  }
+
+  upstream api_backend {
+    server tesler-doc-node-1:8080;
+    server tesler-doc-node-2:8080;
+  }
+}

--- a/tesler-doc-app/pom.xml
+++ b/tesler-doc-app/pom.xml
@@ -52,6 +52,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.zalando</groupId>
+            <artifactId>logbook-spring-boot-starter</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tesler-doc-app/pom.xml
+++ b/tesler-doc-app/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>spring-boot-starter-jdbc</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.session</groupId>
+            <artifactId>spring-session-jdbc</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
         </dependency>

--- a/tesler-doc-app/src/main/resources/application.properties
+++ b/tesler-doc-app/src/main/resources/application.properties
@@ -12,3 +12,8 @@ tesler-docapp.ui-path=/ui
 server.use-forward-headers=true
 spring.session.store-type=jdbc
 spring.session.jdbc.initialize-schema=always
+
+logbook.include=/api/**
+
+logbook.filter.enabled=true
+logbook.format.style=http

--- a/tesler-doc-app/src/main/resources/application.properties
+++ b/tesler-doc-app/src/main/resources/application.properties
@@ -10,3 +10,5 @@ spring.liquibase.change-log=classpath:/db/migration/liquibase/master.xml
 
 tesler-docapp.ui-path=/ui
 server.use-forward-headers=true
+spring.session.store-type=jdbc
+spring.session.jdbc.initialize-schema=always

--- a/tesler-doc-app/src/main/resources/logback-spring.xml
+++ b/tesler-doc-app/src/main/resources/logback-spring.xml
@@ -8,6 +8,7 @@
     </encoder>
   </appender>
 
+  <logger name="org.zalando.logbook" level="TRACE" />
   <root level="INFO">
     <appender-ref ref="STDOUT"/>
   </root>

--- a/tesler-doc-base/pom.xml
+++ b/tesler-doc-base/pom.xml
@@ -52,6 +52,8 @@
     <docker.pull.newerimage>false</docker.pull.newerimage>
     <docker.deploy.phase>verify</docker.deploy.phase>
 
+    <ui.build.command>build</ui.build.command>
+
   </properties>
 
   <profiles>
@@ -66,6 +68,12 @@
       <id>Tests</id>
       <properties>
         <perform.build.only>false</perform.build.only>
+      </properties>
+    </profile>
+    <profile>
+      <id>Limit</id>
+      <properties>
+          <ui.build.command>build:limit</ui.build.command>
       </properties>
     </profile>
     <profile>

--- a/tesler-doc-base/pom.xml
+++ b/tesler-doc-base/pom.xml
@@ -29,9 +29,10 @@
     <spring.version>5.1.9.RELEASE</spring.version>
     <spring-boot.version>2.1.7.RELEASE</spring-boot.version>
     <spring-session-jdbc.version>2.1.7.RELEASE</spring-session-jdbc.version>
+    <logbook.version>2.2.1</logbook.version>
     <liquibase.version>3.6.3</liquibase.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <tesler.version>3.0.2-SNAPSHOT</tesler.version>
+    <tesler.version>3.0.0-SNAPSHOT</tesler.version>
 
     <junit.jupiter.version>5.1.0</junit.jupiter.version>
     <junit.platform.version>1.1.0</junit.platform.version>
@@ -138,6 +139,12 @@
         <groupId>org.springframework.session</groupId>
         <artifactId>spring-session-jdbc</artifactId>
         <version>${spring-session-jdbc.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.zalando</groupId>
+        <artifactId>logbook-spring-boot-starter</artifactId>
+        <version>${logbook.version}</version>
       </dependency>
 
       <dependency>

--- a/tesler-doc-base/pom.xml
+++ b/tesler-doc-base/pom.xml
@@ -28,9 +28,10 @@
 
     <spring.version>5.1.9.RELEASE</spring.version>
     <spring-boot.version>2.1.7.RELEASE</spring-boot.version>
+    <spring-session-jdbc.version>2.1.7.RELEASE</spring-session-jdbc.version>
     <liquibase.version>3.6.3</liquibase.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <tesler.version>3.0.0.M2</tesler.version>
+    <tesler.version>3.0.2-SNAPSHOT</tesler.version>
 
     <junit.jupiter.version>5.1.0</junit.jupiter.version>
     <junit.platform.version>1.1.0</junit.platform.version>
@@ -131,6 +132,12 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-jdbc</artifactId>
         <version>${spring-boot.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.session</groupId>
+        <artifactId>spring-session-jdbc</artifactId>
+        <version>${spring-session-jdbc.version}</version>
       </dependency>
 
       <dependency>

--- a/tesler-doc-ui/package.json
+++ b/tesler-doc-ui/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "webpack --mode=production",
+    "build:limit": "node --max_old_space_size=1024 node_modules/.bin/webpack --mode=production",
     "start": "webpack-dev-server",
     "start:sso": "webpack-dev-server",
     "lint": "tslint 'src/**/*.ts{,x}' 'src/**/*.js' '*webpack.config.js'",

--- a/tesler-doc-ui/package.json
+++ b/tesler-doc-ui/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://idocs.tesler.io/",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "node --max_old_space_size=1024 node_modules/.bin/webpack --mode=production",
+    "build": "webpack --mode=production",
     "start": "webpack-dev-server",
     "start:sso": "webpack-dev-server",
     "lint": "tslint 'src/**/*.ts{,x}' 'src/**/*.js' '*webpack.config.js'",

--- a/tesler-doc-ui/pom.xml
+++ b/tesler-doc-ui/pom.xml
@@ -88,7 +88,7 @@
               <executable>npm</executable>
               <arguments>
                 <argument>run</argument>
-                <argument>build</argument>
+                <argument>${ui.build.command}</argument>
               </arguments>
             </configuration>
             <goals>


### PR DESCRIPTION
Cluster support with spring session added to tesler in [MR](https://github.com/tesler-platform/tesler/pull/123), so tesler-doc swiched to tesler.version=3.0.0-SNAPSHOT 

Before this MR tesler-doc produced error in cluster mode (see 2 node [scenario](https://www.youtube.com/watch?v=iHdriuhoEu8&feature=youtu.be))

After this MR tesler-doc successfully works in cluster mode (see [scenario](https://www.youtube.com/watch?v=2K2jZy6iGpY&feature=youtu.be) of configuring spring-session-jdbc and working with 2 nodes)

P.S. README.md added. Docker-compose.yml for fast start 2 node cluster added. Convenient http logging with [logbook](https://github.com/zalando/logbook) added (in cluster mode we need to easyly find which node received request)