### PR TITLE
tesler update 3.0.0.M4

### DIFF
--- a/tesler-doc-base/pom.xml
+++ b/tesler-doc-base/pom.xml
@@ -32,7 +32,7 @@
     <logbook.version>2.2.1</logbook.version>
     <liquibase.version>3.6.3</liquibase.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <tesler.version>3.0.0-SNAPSHOT</tesler.version>
+    <tesler.version>3.0.0.M4</tesler.version>
 
     <junit.jupiter.version>5.1.0</junit.jupiter.version>
     <junit.platform.version>1.1.0</junit.platform.version>


### PR DESCRIPTION
Currently documentation relies on snapshot version 3.0.0-SNAPSHOT which requires explicit reference to snapshots repository https://oss.sonatype.org/content/repositories/snapshots