### PR TITLE
npm 7 compatibility through `--legacy-peer-deps` option

### DIFF
--- a/tesler-doc-ui/pom.xml
+++ b/tesler-doc-ui/pom.xml
@@ -45,6 +45,7 @@
               <executable>npm</executable>
               <arguments>
                 <argument>install</argument>
+                <argument>--legacy-peer-deps</argument>
               </arguments>
             </configuration>
             <goals>


### PR DESCRIPTION
NPM 7 (released 2 February 2021) has [a breaking change](https://github.blog/2021-02-02-npm-7-is-now-generally-available/) in way how peer dependencies are handled; previously if there is a mismatch between declared and resolved versions, a warning is produced; now an error is produced and build will fail.

telser-doc-ui is affected as some dependencies were resolved before they were properly declared in tesler-ui as peer dependencies.
To name a few, `npm install` will fail on following dependencies:
* antd - peer dependency ^3.26.18, tesler-doc-ui resolved on 3.26.13
* react-redux - ^7.2.1, tesler-doc-ui resolved on 7.2.0
* redux - peer dependency ^4.0.5 and resolved 4.0.5, but also a peer dependency for redux-observable which has it at 3.*
Nothing to do here aside of adding --legacy-peer-deps option until we migrate to redux-observable ^1.*